### PR TITLE
Replace git-code-format-maven-plugin by spotless-maven-plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ can be incremented even for breaking changes.
 
 ### Changed
 
+- Replace git-code-format-maven-plugin by spotless-maven-plugin (#54).
 - Bump minimum required maven version from 2.8.6 to 2.8.7 (#62).
 - Bump spring-boot-starter-parent from 3.0.0 to 3.0.3 (#57, #59, #60).
 

--- a/README.md
+++ b/README.md
@@ -67,10 +67,8 @@ in your project:
 mvn help:effective-pom
 ```
 
-Note that despite the code target (`this.java.version`) can be Java 8, you will have to
-use at least Java 11 to build it (because maven-git-code-format dropped Java 8 support
-since version 3.x). You must also declare a
-[`maven-versions-rules.xml`](/maven-versions-rules.xml) file at the root of your project.
+You must also declare a [`maven-versions-rules.xml`](/maven-versions-rules.xml) file at the root of
+your project.
 
 ## What's included?
 
@@ -107,8 +105,8 @@ since version 3.x). You must also declare a
   [maven-release-plugin](https://maven.apache.org/maven-release/maven-release-plugin/)
   (change `tagNameFormat`).
 - plugin management for
-  [maven-git-code-format](https://github.com/Cosium/maven-git-code-format)
-  (hooks installation),
+  [spotless-maven-plugin](https://github.com/diffplug/spotless/blob/main/plugin-maven/README.md)
+  (binding to the verify phase),
 - plugin management and project configuration for
   [sonar-maven-plugin](https://sonarsource.github.io/sonar-scanner-maven/),
 - plugin management and project configuration for

--- a/pom.xml
+++ b/pom.xml
@@ -122,13 +122,13 @@
 
     <!-- Plugins -->
     <flatten-maven-plugin.version>1.3.0</flatten-maven-plugin.version>
-    <git-code-format-maven-plugin.version>4.2</git-code-format-maven-plugin.version>
     <maven-gpg-plugin.version>3.0.1</maven-gpg-plugin.version>
     <maven-release-plugin.version>2.5.3</maven-release-plugin.version>
     <maven-site-plugin.version>3.12.1</maven-site-plugin.version>
     <jacoco-maven-plugin.version>0.8.8</jacoco-maven-plugin.version>
     <jib-maven-plugin.version>3.3.1</jib-maven-plugin.version>
     <sonar-maven-plugin.version>3.9.1.2184</sonar-maven-plugin.version>
+    <spotless-maven-plugin.version>2.33.0</spotless-maven-plugin.version>
 
     <!-- Spring Boot properties -->
     <java.version>${this.java.version}</java.version>
@@ -228,40 +228,6 @@
           </configuration>
         </plugin>
 
-        <!--
-          Use it with the appropriate plugin / configuration in your IDE.
-          See https://github.com/google/google-java-format for more information.
-        -->
-        <plugin>
-          <groupId>com.cosium.code</groupId>
-          <artifactId>git-code-format-maven-plugin</artifactId>
-          <version>${git-code-format-maven-plugin.version}</version>
-          <executions>
-            <!-- On commit, format the modified files -->
-            <execution>
-              <id>install-formatter-hook</id>
-              <goals>
-                <goal>install-hooks</goal>
-              </goals>
-            </execution>
-            <!-- On Maven verify phase, fail if any file (including unmodified) is badly formatted -->
-            <execution>
-              <id>validate-code-format</id>
-              <goals>
-                <goal>validate-code-format</goal>
-              </goals>
-            </execution>
-          </executions>
-          <dependencies>
-            <!-- Enable https://github.com/google/google-java-format -->
-            <dependency>
-              <groupId>com.cosium.code</groupId>
-              <artifactId>google-java-format</artifactId>
-              <version>${git-code-format-maven-plugin.version}</version>
-            </dependency>
-          </dependencies>
-        </plugin>
-
         <plugin>
           <artifactId>maven-release-plugin</artifactId>
           <version>${maven-release-plugin.version}</version>
@@ -279,6 +245,20 @@
           <groupId>org.sonarsource.scanner.maven</groupId>
           <artifactId>sonar-maven-plugin</artifactId>
           <version>${sonar-maven-plugin.version}</version>
+        </plugin>
+
+        <plugin>
+          <groupId>com.diffplug.spotless</groupId>
+          <artifactId>spotless-maven-plugin</artifactId>
+          <version>${spotless-maven-plugin.version}</version>
+          <executions>
+            <!-- spotless:check is bound to verify maven phase by default -->
+            <execution>
+              <goals>
+                <goal>check</goal>
+              </goals>
+            </execution>
+          </executions>
         </plugin>
 
         <!-- https://stackoverflow.com/q/10230903 -->


### PR DESCRIPTION
git-code-format-maven-plugin imposed a lot of breaking changes lately (most due to Google Java Format), which was a pain to resolve. And spotless-maven-plugin is way more configurable.